### PR TITLE
update Pokemon API to access nicer images

### DIFF
--- a/src/Pokecard.js
+++ b/src/Pokecard.js
@@ -1,10 +1,13 @@
 import React, {Component} from 'react';
 import './Pokecard.css';
-const POKE_API = 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/';
+// const POKE_API = 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/';
+const POKE_API = 'https://assets.pokemon.com/assets/cms2/img/pokedex/detail/'
+
+let padToThree = (number) => (number <=999 ? `00${number}`.slice(-3) : number);
 
 class Pokecard extends Component {
     render() {
-        let imgSrc = `${POKE_API}${this.props.id}.png`;
+        let imgSrc = `${POKE_API}${padToThree(this.props.id)}.png`;
         return (
             <div className="Pokecard">
                 <h1 className="Pokecard-title">{this.props.name}</h1>


### PR DESCRIPTION
This updates the `POKE_API` to a different API that uses nicer, higher-resolution images.  The changes are made in the 'Pokecard.js' file.  Also a function named `padToThree` was added, to create a 3-digit number from each image number provided.  They will then work with this specific API.