### PR TITLE
add Pokegame component with logic

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,12 @@
 import React, {Component} from 'react';
-import Pokedex from './Pokedex';
+import Pokegame from './Pokegame';
 import './App.css';
 
 class App extends Component {
   render() {
     return (
       <div className="App">
-        <Pokedex />
+        <Pokegame />
       </div>
     );      
   }

--- a/src/Pokegame.js
+++ b/src/Pokegame.js
@@ -1,8 +1,7 @@
 import React, { Component } from 'react';
-import Pokecard from './Pokecard';
-import './Pokedex.css';
+import Pokedex from './Pokedex';
 
-class Pokedex extends Component {
+class Pokegame extends Component {
     static defaultProps = {
         pokemon : [
             {id: 4, name: 'Charmander', type: 'fire', base_experience: 62},
@@ -15,20 +14,25 @@ class Pokedex extends Component {
             {id: 133, name: 'Eevee', type: 'normal', base_experience: 65}
         ]
     };
-    render() {
+    render() {        
+        let hand1 = [];
+        let hand2 = [ ...this.props.pokemon];
+        while (hand1.length < hand2.length) {
+            let ranIdx = Math.floor(Math.random() * hand2.length);
+            let ranPokemon = hand2.splice(ranIdx, 1)[0];
+            hand1.push(ranPokemon);
+        }
+        let exp1 = hand1.reduce((exp, pokemon) => exp + pokemon.base_experience,
+        0);     
+        let exp2 = hand2.reduce((exp, pokemon) => exp + pokemon.base_experience,
+        0);     
         return (
-        <div className="Pokedex">
-            <h1>Pokedex!</h1>
-            <p>Total Experience {this.props.exp} </p>
-            <p>{this.props.isWinner ? 'Winner!' : 'Loser!'}</p>
-            <div className="Pokedex-cards">
-                {this.props.pokemon.map((p) => (
-                    <Pokecard id={p.id} name={p.name} type={p.type} exp={p.base_experience} />
-                ))};
+            <div>
+                <Pokedex pokemon={hand1} exp={exp1} isWinner={exp1 > exp2} />
+                <Pokedex pokemon={hand2} exp={exp2} isWinner={exp2 > exp1} />
             </div>
-        </div>
         );
     }
 }
 
-export default Pokedex;
+export default Pokegame;


### PR DESCRIPTION
This adds a `Pokegame` component inside the 'Pokegame.js' file.  The pokemon `defaultProps` were copied over to this file from 'Pokedex.js'. The logic in this new component allows for a game of two random hands, and the experience points to be added together for each hand.

Also in the 'App.js' file, the `Pokegame` component was passed in, instead of the `Pokedex` component.  Also in the 'Pokedex.js' file, the "Total Experience" is displayed.  The winner or loser is identified for the higher and lower hand.